### PR TITLE
- added usage of system audio to allow powering on an AVR...

### DIFF
--- a/include/linux/amlogic/hdmi_tx/hdmi_tx_cec.h
+++ b/include/linux/amlogic/hdmi_tx/hdmi_tx_cec.h
@@ -390,6 +390,7 @@ typedef unsigned long cec_info_mask;
 #define ONE_TOUCH_PLAY_MASK                  1
 #define ONE_TOUCH_STANDBY_MASK               2
 #define AUTO_POWER_ON_MASK                   3
+#define SYSTEM_AUDIO_MASK                    6
 
 
 typedef struct {
@@ -599,6 +600,10 @@ void cec_report_physical_address_smp(void);
 void cec_imageview_on_smp(void);
 void cec_active_source_smp(void);
 void cec_active_source_rx(cec_rx_message_t* pcec_message);
+
+void cec_system_audio_mode_request_smp(void);
+void cec_system_audio_mode_release_smp(void);
+void cec_inactive_source_smp(void);
 
 size_t cec_usrcmd_get_global_info(char * buf);
 void cec_usrcmd_set_dispatch(const char * buf, size_t count);


### PR DESCRIPTION
- added usage of system audio to allow powering on an AVR.
  If ONE_TOUCH_PLAY_MASK (bit 1) and SYSTEM_AUDIO_MASK (bit 6) in cec_config
  are set, system audio will be requested. Clearing SYSTEM_AUDIO_MASK will
  release system audio.
- changed behavior on stop of cec.
  The driver releases now system audio and active source so that the AVR and
  TV switch to live TV instead of showing an error message because of lost
  signal.
