### PR TITLE
fixed merging error of your merge with upstream kernel and system audio extension as before

### DIFF
--- a/drivers/amlogic/hdmi/hdmi_tx/hdmi_tx_cec.c
+++ b/drivers/amlogic/hdmi/hdmi_tx/hdmi_tx_cec.c
@@ -742,7 +742,7 @@ static irqreturn_t cec_isr_handler(int irq, void *dev_instance)
     //cec_disable_irq();
     hdmitx_dev_t* hdmitx;
 #if MESON_CPU_TYPE >= MESON_CPU_TYPE_MESON8
-    unsigned int intr_stat;
+    unsigned int intr_stat = 0;
     intr_stat = aml_read_reg32(P_AO_CEC_INTR_STAT);
     if (cec_msg_dbg_en  == 1)
     {

--- a/drivers/amlogic/hdmi/hdmi_tx/hdmi_tx_cec.c
+++ b/drivers/amlogic/hdmi/hdmi_tx/hdmi_tx_cec.c
@@ -2173,6 +2173,9 @@ void cec_usrcmd_set_dispatch(const char * buf, size_t count)
         case PING_TV:    //0x1a LA : For TV CEC detected.
             detect_tv_support_cec(param[1]);
             break;
+        case DEVICE_MENU_CONTROL:    //0x1b
+            cec_usrcmd_device_menu_control(param[1], param[2]);
+            break;
         default:
             break;
     }

--- a/include/linux/amlogic/hdmi_tx/hdmi_tx_cec.h
+++ b/include/linux/amlogic/hdmi_tx/hdmi_tx_cec.h
@@ -390,6 +390,7 @@ typedef unsigned long cec_info_mask;
 #define ONE_TOUCH_PLAY_MASK                  1
 #define ONE_TOUCH_STANDBY_MASK               2
 #define AUTO_POWER_ON_MASK                   3
+#define SYSTEM_AUDIO_MASK                    6
 
 
 typedef struct {
@@ -599,6 +600,10 @@ void cec_report_physical_address_smp(void);
 void cec_imageview_on_smp(void);
 void cec_active_source_smp(void);
 void cec_active_source_rx(cec_rx_message_t* pcec_message);
+
+void cec_system_audio_mode_request_smp(void);
+void cec_system_audio_mode_release_smp(void);
+void cec_inactive_source_smp(void);
 
 size_t cec_usrcmd_get_global_info(char * buf);
 void cec_usrcmd_set_dispatch(const char * buf, size_t count);


### PR DESCRIPTION
```
fixed merging error of your merge with upstream kernel

added usage of system audio to allow powering on an AVR.
If ONE_TOUCH_PLAY_MASK (bit 1) and SYSTEM_AUDIO_MASK (bit 6) in cec_config
are set, system audio will be requested. Clearing SYSTEM_AUDIO_MASK will
release system audio.

changed behavior on stop of cec.
The driver releases now system audio and active source so that the AVR and
TV switch to live TV instead of showing an error message because of lost
signal.
```
